### PR TITLE
Changed to ContentDate from PublishedDate

### DIFF
--- a/src/components/PoliceNewsRoomCard.jsx
+++ b/src/components/PoliceNewsRoomCard.jsx
@@ -10,7 +10,7 @@ import React from "react";
 
 const NewsRoomCard = (props) => {
   const {
-    publishDate,
+    contentDate,
     title,
     articleSummary,
     thumbnail,
@@ -24,7 +24,10 @@ const NewsRoomCard = (props) => {
     day: "numeric",
   };
 
-  const published = new Date(publishDate).toLocaleDateString("en-US", options);
+  const articleDate = new Date(contentDate).toLocaleDateString(
+    "en-US",
+    options
+  );
 
   return (
     <Card className="text-left">
@@ -40,7 +43,7 @@ const NewsRoomCard = (props) => {
             />
           </div>
           <div className="col-sm-9 col-xs-12">
-            <p>{published}</p>
+            <p>{articleDate}</p>
             <p>{articleSummary}</p>
           </div>
         </div>


### PR DESCRIPTION
This is a bug Matt found where we sort by content date but displayed published date. Published date has no meaning to the news article so we need to change the date displayed to content date.